### PR TITLE
remove harmony flag

### DIFF
--- a/bin/grpcc.js
+++ b/bin/grpcc.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
 
 'use strict';
 


### PR DESCRIPTION
the hashbang breaks the binary on linux by passing two arguments